### PR TITLE
Security for Authentication

### DIFF
--- a/backend/src/authentication/authentication.module.ts
+++ b/backend/src/authentication/authentication.module.ts
@@ -4,10 +4,9 @@ import { LoginService } from './login/login.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { TwoFactorController } from './two-factor/two-factor.controller';
 import { TwoFactorService } from './two-factor/two-factor.service';
-import { UserService } from 'src/user/user.service';
 
 @Module({
   controllers: [LoginController, TwoFactorController],
-  providers: [LoginService, TwoFactorService, PrismaService, UserService],
+  providers: [LoginService, TwoFactorService, PrismaService],
 })
 export class LoginModule {}

--- a/backend/src/authentication/login/login.controller.ts
+++ b/backend/src/authentication/login/login.controller.ts
@@ -1,10 +1,9 @@
 import { Controller, Post, Body, BadRequestException } from '@nestjs/common';
 import { LoginService } from './login.service'; 
-import { UserService } from 'src/user/user.service';
 
 @Controller('login')
 export class LoginController {
-  constructor(private readonly loginService: LoginService, private readonly userService: UserService) {}
+  constructor(private readonly loginService: LoginService) {}
 
   @Post('get-token')
   async getToken(@Body() body: { code: string; state: string }) {
@@ -13,8 +12,7 @@ export class LoginController {
       throw new BadRequestException('Invalid state');
     }
     const token = await this.loginService.getToken(code);
-    const user = await this.loginService.getIntraName(token.access_token);
-    return { token, user };
+    return token;
   }
 
   @Post('online')
@@ -25,9 +23,10 @@ export class LoginController {
   }
 
   @Post('offline')
-  async offline(@Body() body: { userID: number }) {
-    const { userID } = body;
-    this.loginService.setUserStatusToOffline(userID);
+  async offline(@Body() body: { token: string }) {
+    const { token } = body;
+    const user = await this.loginService.getIntraName(token);
+    this.loginService.setUserStatusToOffline(user);
   }
 
 
@@ -43,13 +42,5 @@ export class LoginController {
     const { token } = body;
     const login = await this.loginService.getIntraName(token);
     return login;
-  }
-
-  @Post('user-id')
-  async getUserIDFromToken(@Body() body: { token: string }) {
-    const { token } = body;
-    const intraName = await this.loginService.getIntraName(token);
-    const userID = await this.userService.getUserIDByIntraUsername(intraName);
-    return userID;
   }
 }

--- a/backend/src/authentication/login/login.service.ts
+++ b/backend/src/authentication/login/login.service.ts
@@ -60,10 +60,10 @@ export class LoginService {
     }
   }
 
-  async setUserStatusToOffline(userID: number): Promise<void> {
+  async setUserStatusToOffline(intraUsername: string): Promise<void> {
     try {
       await this.prisma.user.update({
-        where: { ID: userID },
+        where: { intraUsername: intraUsername },
         data: { status: UserStatus.OFFLINE },
       });
     }

--- a/backend/src/authentication/two-factor/two-factor.controller.ts
+++ b/backend/src/authentication/two-factor/two-factor.controller.ts
@@ -1,42 +1,50 @@
 import { Controller, Post, Get, Body } from '@nestjs/common';
 import { TwoFactorService } from './two-factor.service';
-import { UserService } from 'src/user/user.service';
+import { LoginService } from '../login/login.service';
 
 @Controller('two-factor')
 export class TwoFactorController {
-  constructor(private readonly twoFactorService: TwoFactorService, private readonly userService: UserService) {}
+
+  constructor(
+    private readonly twoFactorService: TwoFactorService, 
+    private readonly loginService: LoginService
+  ) {}
 
   @Post('qrcode')
-  async qrcode(@Body() body: { userID: number }) {
-    const { userID } = body;
-    const qrcode = await this.twoFactorService.getQRCode(userID);
+  async qrcode(@Body() body: { token: string }) {
+    const { token } = body;
+    const intraUsername = await this.loginService.getIntraName(token);
+    const qrcode = await this.twoFactorService.getQRCode(intraUsername);
     return qrcode
   }
 
   @Post('is-enabled')
-  async isEnabled(@Body() body: { intraName: string }) {
-    const { intraName } = body;
-    const userID = await this.userService.getUserIDByIntraUsername(intraName);
-    const isEnabled = await this.twoFactorService.isTwoFactorEnabled(userID);
-    return { userID, isEnabled }
+  async isEnabled(@Body() body: { token: string }) {
+    const { token } = body;
+    const intraUsername = await this.loginService.getIntraName(token);
+    const isEnabled = await this.twoFactorService.isTwoFactorEnabled(intraUsername);
+    return isEnabled
   }
 
   @Post('verify')
-  async verify(@Body() body: { oneTimePassword: string, userID: number }) {
-    const { oneTimePassword, userID } = body;
-    const verified = await this.twoFactorService.verifyOneTimePassword(oneTimePassword, userID);
+  async verify(@Body() body: { oneTimePassword: string, token: string }) {
+    const { oneTimePassword, token } = body;
+    const intraUsername = await this.loginService.getIntraName(token);
+    const verified = await this.twoFactorService.verifyOneTimePassword(oneTimePassword, intraUsername);
     return verified
   }
 
   @Post('enable')
-  async enable(@Body() body: { userID: number }) {
-    const { userID } = body;
-    await this.twoFactorService.enableTwoFactor(userID);
+  async enable(@Body() body: { token: string }) {
+    const { token } = body;
+    const intraUsername = await this.loginService.getIntraName(token);
+    await this.twoFactorService.enableTwoFactor(intraUsername);
   }
 
   @Post('disable')
-  async disable(@Body() body: { userID: number }) {
-    const { userID } = body;
-    await this.twoFactorService.disableTwoFactor(userID);
+  async disable(@Body() body: { token: string }) {
+    const { token } = body;
+    const intraUsername = await this.loginService.getIntraName(token);
+    await this.twoFactorService.disableTwoFactor(intraUsername);
   }
 }

--- a/backend/src/authentication/two-factor/two-factor.service.ts
+++ b/backend/src/authentication/two-factor/two-factor.service.ts
@@ -8,14 +8,14 @@ export class TwoFactorService {
 
 	constructor(private prisma: PrismaService) {}
 
-	async getQRCode(userID: number): Promise<any> {
+	async getQRCode(intraUsername: string): Promise<any> {
 		try {
 			var secret = speakeasy.generateSecret({
 				name: "Transcendancing Queens"
 			});
 			const dataURL = await qrcode.toDataURL(secret.otpauth_url);
 			await this.prisma.user.update({
-				where: { ID: userID },
+				where: { intraUsername: intraUsername },
 				data: { secretKey: secret.ascii },
 			});
 			return dataURL
@@ -25,10 +25,10 @@ export class TwoFactorService {
 		}
 	}
 
-	async isTwoFactorEnabled(userID: number): Promise<boolean> {
+	async isTwoFactorEnabled(intraUsername: string): Promise<boolean> {
 		try {
 			const isEnabled = await this.prisma.user.findUnique({
-				where: { ID: userID },
+				where: { intraUsername: intraUsername },
 				select: { Enabled2FA: true },
 			});
 			if (isEnabled === null) {
@@ -42,10 +42,10 @@ export class TwoFactorService {
 		}
 	}
 
-	async verifyOneTimePassword(oneTimePassword: string, userID: number): Promise<boolean> {
+	async verifyOneTimePassword(oneTimePassword: string, intraUsername: string): Promise<boolean> {
 		try {
 			const secretKey = await this.prisma.user.findUnique({
-				where: { ID: userID },
+				where: { intraUsername: intraUsername },
 				select: { secretKey: true },
 			});
 			const verified = speakeasy.totp.verify({
@@ -60,10 +60,10 @@ export class TwoFactorService {
 		}
 	}
 
-	async enableTwoFactor(userID: number): Promise<void> {
+	async enableTwoFactor(intraUsername: string): Promise<void> {
 		try {
 			await this.prisma.user.update({
-				where: { ID: userID },
+				where: { intraUsername: intraUsername },
 				data: { Enabled2FA: true },
 			});
 		}
@@ -72,10 +72,10 @@ export class TwoFactorService {
 		}
 	}
 
-	async disableTwoFactor(userID: number): Promise<void> {
+	async disableTwoFactor(intraUsername: string): Promise<void> {
 		try {
 			await this.prisma.user.update({
-				where: { ID: userID },
+				where: { intraUsername: intraUsername },
 				data: { 
 					secretKey: null,
 					Enabled2FA: false,

--- a/frontend/src/components/Authentication/Enable2FA.tsx
+++ b/frontend/src/components/Authentication/Enable2FA.tsx
@@ -1,13 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import SingleHeader from './Pages/SingleHeader.tsx';
 import { useNavigate } from 'react-router-dom';
 import { verifyOTP, enableTwoFactor } from '../Utils/apiCalls.tsx';
 
-interface Enable2FAProps {
-  userID: number;
-}
-
-const Enable2FA: React.FC<Enable2FAProps> = ({ userID }) => {
+const Enable2FA = () => {
   const navigate = useNavigate();
   const [oneTimePassword, setOneTimePassword] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -20,23 +15,17 @@ const Enable2FA: React.FC<Enable2FAProps> = ({ userID }) => {
     }
   }, [navigateToAccount, navigate]);
 
-  if (!userID) {
-    return <SingleHeader text="User ID not found. Please retry." />;
-  }
-
   const handleVerifyAndEnable = async () => {
     setIsLoading(true);
     setErrorMessage('');
 
     try {
-      const response = await verifyOTP(userID, oneTimePassword);
+			const token = localStorage.getItem('authenticationToken');
+      if (!token) throw new Error('Authentication token not found');
+      const response = await verifyOTP(token, oneTimePassword);
       const verified = response.data;
-
-      if (!verified) {
-        throw new Error('Invalid one-time password');
-      }
-
-      await enableTwoFactor(userID);
+      if (!verified) throw new Error('Invalid one-time password');
+      await enableTwoFactor(token);
       navigate('/account');
     } catch (error) {
       console.error('Error verifying one-time password:', error);

--- a/frontend/src/components/Authentication/LogOut.tsx
+++ b/frontend/src/components/Authentication/LogOut.tsx
@@ -1,34 +1,25 @@
 import React, { useEffect } from 'react';
 import SingleHeader from './Pages/SingleHeader.tsx';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { markUserOffline, getUserIDFromToken } from '../Utils/apiCalls.tsx';
+import { useNavigate } from 'react-router-dom';
+import { markUserOffline } from '../Utils/apiCalls.tsx';
 
 const LogOut = () => {
 	const navigate = useNavigate();
-	const location = useLocation();
-	const userID = location.state?.userID;
 
 	useEffect(() => {
-		const logOutUser = async (userID: number) => {
+		const logOutUser = async () => {
 			try {
-				if (!userID) {
-					const token = localStorage.getItem('authenticationToken');
-					if (!token) {
-						navigate('/');
-						return;
-					}
-					const response = await getUserIDFromToken(token);
-					userID = response.data;
-				}
-				await markUserOffline(userID);
+				const token = localStorage.getItem('authenticationToken');
+      	if (!token) throw new Error('Authentication token not found');
+				await markUserOffline(token);
 			} catch (error) {
 				console.error('Error while logging out');
 			} finally {
-				navigate('/');
 				localStorage.removeItem('authenticationToken');
+				navigate('/');
 			}
 		}
-		logOutUser(userID);
+		logOutUser();
 	}, [navigate]);
 
 	return <SingleHeader text="Logging out..." />;

--- a/frontend/src/components/Authentication/LoginRedirect.tsx
+++ b/frontend/src/components/Authentication/LoginRedirect.tsx
@@ -22,15 +22,15 @@ const LoginRedirect = () => {
 
     const handleLoginRedirect = async () => {
       try {
+      
         const tokenResponse = await getToken(code, state);
-        const user = tokenResponse.data.user;
-        const token = tokenResponse.data.token;
-        
+        const token = tokenResponse.data;
+
         try {
-          const isEnabledResponse = await isTwoFactorEnabled(user);
-          if (isEnabledResponse.data.isEnabled) {
+          const isEnabledResponse = await isTwoFactorEnabled(token.access_token);
+          if (isEnabledResponse.data) {
             localStorage.setItem('tempToken', token.access_token);
-            navigate('/login/verify-2fa', { state: { userID: isEnabledResponse.data.userID } });
+            navigate('/login/verify-2fa');
             return;
           }
         } catch { }

--- a/frontend/src/components/Authentication/SetUp2FA.tsx
+++ b/frontend/src/components/Authentication/SetUp2FA.tsx
@@ -12,16 +12,12 @@ const SetUp2FA = () => {
 	const [userScannedQRCode, setUserScannedQRCode] = useState<boolean>(false);
 
   useEffect(() => {
-    const userID = location.state?.userID;
-    if (!userID) {
-      console.error('Error getting userID from location');
-      setErrorOccurred(true);
-      return;
-    }
 
-		const displayQRCode = async (userID: number) => {
+		const displayQRCode = async () => {
 			try {
-				const response = await getQRCode(userID);
+				const token = localStorage.getItem('authenticationToken');
+      	if (!token) throw new Error('Authentication token not found');
+				const response = await getQRCode(token);
 				setQrcodeUrl(response.data);
 				setCodeIsFetched(true);
 			} catch (error) {
@@ -32,16 +28,16 @@ const SetUp2FA = () => {
 		}
 
     if (!codeIsFetched) {
-			displayQRCode(userID);
+			displayQRCode();
 		}
-  }, [location.state, codeIsFetched]);
+  }, [codeIsFetched]);
 
 	if (errorOccurred) {
 		return <SingleHeader text="Error occurred while setting up 2FA" />;
 	} else if (!codeIsFetched) {
     return <SingleHeader text="Loading..." />;
   } else if (userScannedQRCode) {
-		return <Enable2FA userID={location.state?.userID} />;
+		return <Enable2FA />;
 	} else {
     return (
 			<div className="card shadow d-flex justify-content-center align-items-center p-3 m-3">

--- a/frontend/src/components/Authentication/Verify2FA.tsx
+++ b/frontend/src/components/Authentication/Verify2FA.tsx
@@ -1,32 +1,22 @@
 import React, { useState } from 'react';
-import SingleHeader from './Pages/SingleHeader.tsx';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { verifyOTP, markUserOnline } from '../Utils/apiCalls.tsx';
 
-interface LocationState {
-  userID: string;
-}
 
 const Verify2FA = () => {
 	const navigate = useNavigate();
-  const location = useLocation<LocationState>();
 	const [oneTimePassword, setOneTimePassword] = useState<string>('');
 	const [isLoading, setIsLoading] = useState<boolean>(false);
 	const [errorMessage, setErrorMessage] = useState<string>('');
 
-	const userID = location.state?.userID;
-	if (!userID) {
-		return <SingleHeader text="User ID not found. Please retry." />;
-	}
-
 	const verifyOneTimePassword = async () => {
 		setIsLoading(true);
 		try {
-			const response = await verifyOTP(userID, oneTimePassword);
+			const token = localStorage.getItem('tempToken');
+      if (!token) throw new Error('Authentication token not found');
+			const response = await verifyOTP(token, oneTimePassword);
 			const verified = response.data;
 			if (verified) {
-        const token = localStorage.getItem('tempToken');
-        if (!token) throw new Error('Temporary token not found');
         localStorage.setItem('authenticationToken', token);
         localStorage.removeItem('tempToken');
         await markUserOnline(token);

--- a/frontend/src/components/User/Account/LogOutButton.tsx
+++ b/frontend/src/components/User/Account/LogOutButton.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
-interface LogOutButtonProps {
-  userID: number;
-}
 
-const LogOutButton: React.FC<LogOutButtonProps> = ({ userID }) => {
+const LogOutButton = () => {
   const navigate = useNavigate();
 
   const logoutUser = () => {
-    navigate('/logout', { state: { userID } });
+    navigate('/logout');
   }
 
   return (

--- a/frontend/src/components/User/Account/Toggle2FA.tsx
+++ b/frontend/src/components/User/Account/Toggle2FA.tsx
@@ -4,10 +4,9 @@ import { disableTwoFactor } from '../../Utils/apiCalls.tsx';
 
 interface TwoFactorAuthenticationProps {
   twoFactorAuthenticationEnabled: boolean;
-  userID: number;
 }
 
-const Toggle2FA: React.FC<TwoFactorAuthenticationProps> = ({ twoFactorAuthenticationEnabled, userID }) => {
+const Toggle2FA: React.FC<TwoFactorAuthenticationProps> = ({ twoFactorAuthenticationEnabled }) => {
   const [twoFactorEnabled, setTwoFactorEnabled] = useState(twoFactorAuthenticationEnabled);
   const navigate = useNavigate();
 
@@ -16,12 +15,14 @@ const Toggle2FA: React.FC<TwoFactorAuthenticationProps> = ({ twoFactorAuthentica
   }, [twoFactorAuthenticationEnabled]);
 
   const enable2FA = async () => {
-    navigate('/login/set-up-2fa', { state: { userID } });
+    navigate('/login/set-up-2fa');
   };
 
   const disable2FA = async () => {
     try {
-      await disableTwoFactor(userID);
+      const token = localStorage.getItem('authenticationToken');
+      if (!token) throw new Error('Authentication token not found');
+      await disableTwoFactor(token);
       setTwoFactorEnabled(false);
       alert('Two-factor authentication has been disabled successfully.');
     } catch (error) {

--- a/frontend/src/components/Utils/apiCalls.tsx
+++ b/frontend/src/components/Utils/apiCalls.tsx
@@ -8,10 +8,10 @@ export const getToken = (code: string, state: string) =>
 	});
 
 
-export const verifyOTP = (userID: string, oneTimePassword: string) =>
+export const verifyOTP = (token: string, oneTimePassword: string) =>
   axios.post('http://localhost:3001/two-factor/verify', {
-    userID,
-    oneTimePassword,
+    oneTimePassword: oneTimePassword,
+    token: token,
   });
 
 
@@ -19,25 +19,21 @@ export const markUserOnline = (token: string) =>
   axios.post('http://localhost:3001/login/online', { token });
 
 
-export const markUserOffline = (userID: number) =>
-  axios.post('http://localhost:3001/login/offline', { userID });
+export const markUserOffline = (token: string) =>
+  axios.post('http://localhost:3001/login/offline', { token });
 
 
-export const isTwoFactorEnabled = (intraName: string) =>
-	axios.post('http://localhost:3001/two-factor/is-enabled', { intraName });
+export const isTwoFactorEnabled = (token: string) =>
+	axios.post('http://localhost:3001/two-factor/is-enabled', { token });
 
 
-export const enableTwoFactor = (userID: number) =>
-	axios.post('http://localhost:3001/two-factor/enable', { userID });
+export const enableTwoFactor = (token: string) =>
+	axios.post('http://localhost:3001/two-factor/enable', { token });
 
 
-export const disableTwoFactor = (userID: number) =>
-	axios.post('http://localhost:3001/two-factor/disable', { userID });
+export const disableTwoFactor = (token: string) =>
+	axios.post('http://localhost:3001/two-factor/disable', { token });
 
 
-export const getQRCode = (userID: number) =>
-	axios.post('http://localhost:3001/two-factor/qrcode', { userID });
-
-
-export const getUserIDFromToken = (token: string) =>
-	axios.post('http://localhost:3001/login/user-id', { token });
+export const getQRCode = (token: string) =>
+	axios.post('http://localhost:3001/two-factor/qrcode', { token });

--- a/frontend/src/pages/UserAccount.tsx
+++ b/frontend/src/pages/UserAccount.tsx
@@ -62,13 +62,13 @@ function UserAccount() {
           <div className="card shadow mb-4">
             <div className="card-body">
               <div className="d-flex justify-content-center align-items-center">
-              <Toggle2FA twoFactorAuthenticationEnabled={userData.Enabled2FA} userID={userData.ID} />
+              <Toggle2FA twoFactorAuthenticationEnabled={userData.Enabled2FA} />
               </div>
             </div>
           </div>
           <div className="card shadow mb-4">
             <div className="card-body">
-              <LogOutButton userID={userData.ID}/>
+              <LogOutButton />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description
Makes the auth backend more secure, by protecting against malicious attacks. The only real change is that I'm using authentication token instead of userID for my auth endpoints.

## Explanation
- Previously I was sending userID to the backend. 
- This is problematic because someone might use a tool like curl to send a userID of their own choosing, and this would have modified the database for that user even though that user is not logged in. 
- I changed the auth endpoints to always require the auth token instead of the userID or userIntraname. 
- Then with the token I get the userIntraname from the 42 API and use that to find the user in the database. 

## Testing
I tested manually to verify all functionality is the same.